### PR TITLE
feat: Add option fader. And fix the fader overflows the window.

### DIFF
--- a/doc/beacon.txt
+++ b/doc/beacon.txt
@@ -56,6 +56,7 @@ default configuration is:
 	enable = true,
 	size = 40,
 	fade = true,
+	fader = 'cursor_end',
 	minimal_jump = 10,
 	show_jumps = true,
 	focus_gained = false,
@@ -77,6 +78,9 @@ Beacon size.
 							   *beacon-config.fade*
 fade		    bool (default:true)
 Whether to enable fading animation.
+							   *beacon-config.fader*
+fader		    string (default:'cursor_end')
+Choose different fading animation. Available value: 'cursor_end', 'cursor_line'
 						   *beacon-config.minimal_jump*
 minimal_jump	    int (default:10)
 The jump length which beacon considers significant jump.

--- a/lua/beacon/config.lua
+++ b/lua/beacon/config.lua
@@ -4,6 +4,7 @@ local default_config = {
   enable = true,
   size = 40,
   fade = true,
+  fader = 'cursor_end',
   minimal_jump = 10,
   show_jumps = true,
   focus_gained = false,

--- a/lua/beacon/fader.lua
+++ b/lua/beacon/fader.lua
@@ -56,6 +56,32 @@ M.fade_window = function()
   end
 end
 
+local faders = {
+  cursor_end = function(opts)
+    return vim.tbl_extend('force', opts, {
+      relative = 'cursor',
+      width = math.min(config.size, vim.api.nvim_win_get_width(0) - vim.fn.wincol()),
+      col = 0,
+      row = 0,
+    })
+  end,
+
+  cursor_line = function(opts)
+    local curWin = {
+      pos = vim.api.nvim_win_get_position(0), -- {row, col}
+      width = vim.api.nvim_win_get_width(0),
+    }
+
+    return vim.tbl_extend('force', opts, {
+      relative = 'win',
+      win = 0,
+      width = math.min(config.size, curWin.width),
+      col = curWin.pos[2],
+      row = vim.fn.winline() - 1,
+    })
+  end,
+}
+
 M.highlight_position = function(is_force)
   if config.enable == false and is_force == false then
     return
@@ -76,16 +102,18 @@ M.highlight_position = function(is_force)
     return
   end
 
-  local opts = {
-    relative = 'cursor',
-    width = config.size,
+  local fader = faders[config.fader]
+  if not fader then
+    error('Invalid config.fader = ' .. config.fader)
+  end
+
+  local opts = fader({
     height = 1,
-    col = 0,
-    row = 0,
     anchor = 'NW',
     style = 'minimal',
     focusable = false,
-  }
+  })
+
   -- some plugins wipe out the buffer, so here need to create a new one
   if not vim.api.nvim_buf_is_valid(fake_buf) then
     fake_buf = vim.api.nvim_create_buf(false, true)


### PR DESCRIPTION
- keep previous fader effect default, named with 'cursor_end'.
- fader='cursor_line' will flash whole cursor line in current window.
- fix the fader overflows the window when fader='cursor_end'.